### PR TITLE
make anonymous id accessible

### DIFF
--- a/android/src/main/java/com/smore/RNSegmentIOAnalytics/RNSegmentIOAnalyticsModule.java
+++ b/android/src/main/java/com/smore/RNSegmentIOAnalytics/RNSegmentIOAnalyticsModule.java
@@ -65,6 +65,17 @@ public class RNSegmentIOAnalyticsModule extends ReactContextBaseJavaModule {
   }
 
   /*
+   https://segment.com/docs/connections/sources/catalog/libraries/mobile/android/#anonymousid
+   */
+  @ReactMethod
+  public String anonymousId() {
+    if (!mEnabled) {
+      return "";
+    }
+    return Analytics.with(getReactApplicationContext().getApplicationContext()).getAnalyticsContext().traits().anonymousId();
+  }
+
+  /*
    https://segment.com/docs/libraries/android/#flushing
    */
   @ReactMethod

--- a/index.js
+++ b/index.js
@@ -43,6 +43,14 @@ export default {
     },
 
     /*
+     * https://segment.com/docs/connections/sources/catalog/libraries/mobile/ios/#anonymousid
+     * https://segment.com/docs/connections/sources/catalog/libraries/mobile/android/#anonymousid
+     */
+    anonymousId: function () {
+        return NativeRNSegmentIOAnalytics.anonymousId()
+    },
+
+    /*
      * https://segment.com/docs/libraries/ios/#reset
      * https://segment.com/docs/libraries/android/#how-do-you-handle-unique-identifiers-
      */

--- a/ios/RNAnalytics/RNSegmentIOAnalytics.m
+++ b/ios/RNAnalytics/RNSegmentIOAnalytics.m
@@ -27,11 +27,19 @@ RCT_EXPORT_METHOD(identify:(NSString*)userId traits:(NSDictionary *)traits optio
 RCT_EXPORT_METHOD(track:(NSString*)event properties:(NSDictionary *)properties options:(NSDictionary *)options) {
     [[SEGAnalytics sharedAnalytics] track:event properties:properties options:options];
 }
+
 /*
  https://segment.com/docs/libraries/ios/#screen
  */
 RCT_EXPORT_METHOD(screen:(NSString*)screenName properties:(NSDictionary *)properties options:(NSDictionary *)options) {
     [[SEGAnalytics sharedAnalytics] screen:screenName properties:properties options:options];
+}
+
+/*
+ https://segment.com/docs/connections/sources/catalog/libraries/mobile/ios/#anonymousid
+ */
+RCT_EXPORT_METHOD(anonymousId) {
+    return [[SEGAnalytics sharedAnalytics] getAnonymousId];
 }
 
 /*

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@krazylabs/react-native-analytics",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "description": "The Analytics API you've always wanted. Now for React Native. Powered by Segment.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This exposes the segment anonymous id for use in the deals-mobile AnalyticsService class.

Ticket: https://app.asana.com/0/1179370212192146/1178780881848768

This is part of a host of changes across webview-post-content, deals-mobile, and react-native-analytics. Each related PR is listed below in order of necessary deployment:

1. This PR (no dependents)
- Once this is in master, we need to push it to npm and upgrade the dependency in deals-mobile
2. https://github.com/KrazyCouponLady/webview-post-content/pull/7 (no dependents)
3. https://github.com/KrazyCouponLady/deals-mobile/pull/1162 (dependent on 1)